### PR TITLE
Preserve original vertex ordering

### DIFF
--- a/src/ofxDelaunay.h
+++ b/src/ofxDelaunay.h
@@ -17,6 +17,13 @@
 #include "ofMain.h"
 #include "Delaunay.h"
 
+struct XYZI{
+	double x, y, z;
+	int i; // index
+};
+
+int XYZICompare(const void *v1, const void *v2);
+
 class ofxDelaunay {
     
 public:
@@ -34,7 +41,7 @@ public:
 	
 private:
     vector<ITRIANGLE> triangles;
-    vector<XYZ> vertices;
+    vector<XYZI> vertices;
 	
 };
 


### PR DESCRIPTION
Since the current triangulation messes up vertex ordering, which is a problem when color/normal/texcoord are used, I changed a bit on the sorting stuff so that `ofxDelaunay::triangleMesh` preserves the same vertex ordering.
