### PR TITLE
Fixes to getPointsForITriangle() and getTriangleForPos()

### DIFF
--- a/src/ofxDelaunay.cpp
+++ b/src/ofxDelaunay.cpp
@@ -60,8 +60,8 @@ int ofxDelaunay::triangulate(){
     int nv = vertices.size();
 	
 	// make clone not to destroy vertices
-	vector<XYZI> verticesTemp = vertices;
-	qsort( &verticesTemp[0], verticesTemp.size(), sizeof( XYZI ), XYZICompare );
+	sortedVertices = vertices;
+	qsort( sortedVertices.data(), sortedVertices.size(), sizeof( XYZI ), XYZICompare );
 	
 	//vertices required for Triangulate
     vector<XYZ> verticesXYZ;
@@ -69,9 +69,9 @@ int ofxDelaunay::triangulate(){
 	//copy XYZIs to XYZ
 	for (int i = 0; i < nv; i++) {
 		XYZ v;
-		v.x = verticesTemp.at(i).x;
-		v.y = verticesTemp.at(i).y;
-		v.z = verticesTemp.at(i).z;
+		v.x = sortedVertices.at(i).x;
+		v.y = sortedVertices.at(i).y;
+		v.z = sortedVertices.at(i).z;
 		verticesXYZ.push_back(v);
 	}
 	
@@ -96,9 +96,9 @@ int ofxDelaunay::triangulate(){
 	
 	//copy triangles
 	for(int i = 0; i < ntri; i++){
-		triangleMesh.addIndex(verticesTemp.at(triangles[ i ].p1).i);
-		triangleMesh.addIndex(verticesTemp.at(triangles[ i ].p2).i);
-		triangleMesh.addIndex(verticesTemp.at(triangles[ i ].p3).i);
+		triangleMesh.addIndex(sortedVertices.at(triangles[ i ].p1).i);
+		triangleMesh.addIndex(sortedVertices.at(triangles[ i ].p2).i);
+		triangleMesh.addIndex(sortedVertices.at(triangles[ i ].p3).i);
 	}
 	
 	return ntri;
@@ -173,9 +173,9 @@ void ofxDelaunay::setPointAtIndex(ofPoint p, int index){
 
 vector<ofPoint> ofxDelaunay::getPointsForITriangle(ITRIANGLE t){
 	vector<ofPoint> pts;
-	pts.push_back( ofPoint(vertices[t.p1].x, vertices[t.p1].y, vertices[t.p1].z));
-	pts.push_back( ofPoint(vertices[t.p2].x, vertices[t.p2].y, vertices[t.p2].z));
-	pts.push_back( ofPoint(vertices[t.p3].x, vertices[t.p3].y, vertices[t.p3].z));
+	pts.push_back( ofPoint(sortedVertices[t.p1].x, sortedVertices[t.p1].y, sortedVertices[t.p1].z));
+	pts.push_back( ofPoint(sortedVertices[t.p2].x, sortedVertices[t.p2].y, sortedVertices[t.p2].z));
+	pts.push_back( ofPoint(sortedVertices[t.p3].x, sortedVertices[t.p3].y, sortedVertices[t.p3].z));
 	return pts;
 }
 

--- a/src/ofxDelaunay.cpp
+++ b/src/ofxDelaunay.cpp
@@ -182,11 +182,14 @@ vector<ofPoint> ofxDelaunay::getPointsForITriangle(ITRIANGLE t){
 ITRIANGLE ofxDelaunay::getTriangleForPos(ofPoint pos){
 	
 	ITRIANGLE ti;
+	ti.p1 = 0;
+	ti.p2 = 0;
+	ti.p3 = 0;
 
 	for(int i = 0; i < ntri ; i++){
-        XYZ p0; p0.x = vertices[triangles[i].p1].x; p0.y = vertices[triangles[i].p1].y; p0.z = vertices[triangles[i].p1].z;
-        XYZ p1; p1.x = vertices[triangles[i].p2].x; p1.y = vertices[triangles[i].p2].y; p1.z = vertices[triangles[i].p2].z;
-        XYZ p2; p2.x = vertices[triangles[i].p3].x; p2.y = vertices[triangles[i].p3].y; p2.z = vertices[triangles[i].p3].z;
+        XYZ p0; p0.x = sortedVertices[triangles[i].p1].x; p0.y = sortedVertices[triangles[i].p1].y; p0.z = sortedVertices[triangles[i].p1].z;
+        XYZ p1; p1.x = sortedVertices[triangles[i].p2].x; p1.y = sortedVertices[triangles[i].p2].y; p1.z = sortedVertices[triangles[i].p2].z;
+        XYZ p2; p2.x = sortedVertices[triangles[i].p3].x; p2.y = sortedVertices[triangles[i].p3].y; p2.z = sortedVertices[triangles[i].p3].z;
 		bool inside = ptInTriangle(pos, p0, p1, p2);
 		if(inside) {
 			ti = triangles[i];

--- a/src/ofxDelaunay.h
+++ b/src/ofxDelaunay.h
@@ -51,9 +51,10 @@ public:
 
 private:
 
-	    vector<XYZI> vertices; //only input of triangulate();
-		vector<ITRIANGLE> triangles; //output of triangulate();
-		int ntri; //# tri
+	vector<XYZI> vertices; //once sorted, these are used in triangulate();
+	vector<XYZI> sortedVertices; //only input of triangulate();
+	vector<ITRIANGLE> triangles; //output of triangulate();
+	int ntri; //# tri
 
 	
 };

--- a/src/ofxDelaunay.h
+++ b/src/ofxDelaunay.h
@@ -51,8 +51,7 @@ public:
 
 private:
 
-	vector<XYZI> vertices; //once sorted, these are used in triangulate();
-	vector<XYZI> sortedVertices; //only input of triangulate();
+	vector<XYZI> vertices; //only input of triangulate();
 	vector<ITRIANGLE> triangles; //output of triangulate();
 	int ntri; //# tri
 


### PR DESCRIPTION
Both of the functions in the title of this pull request were broken and are fixed by this PR. Both functions were broken for the same underlying reason, which is that when the triangulation is done, it uses a vector of sorted vertices, but these two functions previously used the unsorted vertices. This meant that the triangles returned by the `Triangulate()` function were correct for the sorted vertices, but not for the unsorted vertices. However, in `getPointsForITriangle()` and `getTriangleForPos()`, the unsorted vertices were used with the triangles that were correct only for the sorted vertices. The naive solution was simply to store a copy of the sorted vertices for use by these functions.

However, this increases memory usage, so I found another solution, which was to only store the sorted vertices. This required changing `removePointAtIndex()` and `setPointAtIndex()` in a way that made them both less efficient. In the case of `removePointAtIndex()`, all elements must be iterated over (see a comment in the code for the reason). For `setPointAtIndex()`, elements must be iterated over until the matching index is found. However, my guess is that updating and removing points is uncommon in many applications, so the performance hit for these functions is less important than storing two sets of vertices. Perhaps more importantly, this changes the meaning of the `index` parameter of these two functions. Instead of referring to an index in a vector, they refer to a more abstract index of a vertex. If you don't want this, just cherry pick the first two commits in this PR, but in that case, there will be more memory use.

All code in this PR has been tested and I don't think I've missed any test cases. If you want my test code, I can put it up into a branch of my fork of ofxDelaunay or something.

A little note: Lines 204 to 206 of `ofxDelaunay.cpp` in the new version (or something like them) are required because `XYZI` does not have a constructor, so it is considered to be uninitialized by the Visual Studio debugger, which causes a runtime crash.
